### PR TITLE
Fix plinko init error

### DIFF
--- a/script.js
+++ b/script.js
@@ -273,6 +273,12 @@ function initPlinkoGame() {
     const pegs = document.querySelectorAll('.plinko-peg');
     const buckets = document.querySelectorAll('.plinko-bucket');
     const board = document.querySelector('.plinko-board');
+
+    // Abort initialization if the game elements are missing (e.g. on
+    // policy pages that still include this script)
+    if (!dataBall || !dataSize || !pegs.length || !buckets.length || !board) {
+        return;
+    }
     
     // Game state variables
     let isAnimating = false;


### PR DESCRIPTION
## Summary
- avoid running plinko logic on pages without the game

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843f89c9e088326823d3bb181617411